### PR TITLE
Added confirmation message to point-to-register.

### DIFF
--- a/iregister.el
+++ b/iregister.el
@@ -273,7 +273,8 @@ for register-name."
       (when (null (get-register idx))
         (setq stored t)
         (point-to-register idx))
-      (setq idx (+ idx 1)))))
+      (setq idx (+ idx 1))))
+  (message "Point register saved."))
 
 ;;;###autoload
 (defun iregister-jump-to-current-marker ()


### PR DESCRIPTION
First time I used M-u for the function, I wasn't sure that my point was being saved. This code adds a short minibuffer message to confirm the save.
